### PR TITLE
Translation not working

### DIFF
--- a/create_package.md
+++ b/create_package.md
@@ -174,7 +174,8 @@ return [
 ];
 ```
 
-Add \{\{ \_\_(‘helloworld::app.hello-world.name’) \}\} to your application’s view & it will automatically translate it.
+
+Add \{\{ trans('helloworld::app.hola-mundo.name') \}\} to your application’s view & it will automatically translate it.
 
 ![translation-output](assets/images/Bagisto_Docs_Images/PackageDevelopment/translation-output.png){: .screenshot-dimension .center}
 


### PR DESCRIPTION
Change 
Add \{\{ \_\_(‘helloworld::app.hello-world.name’) \}\} to your application’s view & it will automatically translate it.
to
Add \{\{ trans('helloworld::app.hola-mundo.name') \}\} to your application’s view & it will automatically translate it.