### PR TITLE
Adding composer install step to configure artisan command-line

### DIFF
--- a/index.md
+++ b/index.md
@@ -93,6 +93,13 @@ http(s)://example.com/public
 1. composer create-project bagisto/bagisto
 ```
 
+**Now configure artisan command-line interface:**
+
+Inside *bagisto* folder:
+```
+2. composer install
+```
+
 **Now configure your database:**
 
 If the above command was completed successfully, then you'll find directory **bagisto** and all of the code will be inside it.
@@ -110,24 +117,24 @@ Find file **.env** inside **bagisto** directory and set the environment variable
 Although, mailer environment variables are also required to be set up as **Bagisto** requires emails to send to customers and admins for various built-in functionalities.
 
 ```
-2. php artisan migrate
+3. php artisan migrate
 ```
 
 ```
-3. php artisan db:seed
+4. php artisan db:seed
 ```
 
 ```
-4. php artisan vendor:publish
+5. php artisan vendor:publish
 -> Press 0 and then press enter to publish all assets and configurations.
 ```
 
 ```
-5. php artisan storage:link
+6. php artisan storage:link
 ```
 
 ```
-6. composer dump-autoload
+7. composer dump-autoload
 ```
 
 **To execute Bagisto**:


### PR DESCRIPTION
During installation I received the following error, which was only resolved after running the **composer install** command:


`PHP Warning:  require(/home/roni/workspace/bagisto/vendor/autoload.php): failed to open stream: No such file or directory in /home/roni/workspace/bagisto/artisan on line 18
PHP Stack trace:
PHP   1. {main}() /home/roni/workspace/bagisto/artisan:0
PHP Fatal error:  require(): Failed opening required '/home/roni/workspace/bagisto/vendor/autoload.php' (include_path='.:/usr/share/php') in /home/roni/workspace/bagisto/artisan on line 18
PHP Stack trace:
PHP   1. {main}() /home/roni/workspace/bagisto/artisan:0
`